### PR TITLE
Fix missing directory on plotting

### DIFF
--- a/pyjuque/Plotting/__init__.py
+++ b/pyjuque/Plotting/__init__.py
@@ -311,6 +311,8 @@ def PlotData(df,
 
     if save_plot or show_plot:
         file_path = os.path.abspath('graphs')
+        if not os.path.exists(file_path):
+            os.makedirs(file_path)
         plot(fig, filename=os.path.join(file_path, plot_title+'.html'), auto_open=show_plot)
 
     return fig


### PR DESCRIPTION
Hey there!

First, thank you for your amazing work! I have started writing something on my own for algorithmic trading, but it seems like your package can do almost everything I wanted to do in mine (some of them like trailing stop loss are still in development as I see).

This PR today is to fix just a tiny little thing that bothered me: when I ran your `Backtest_Strategy.py` example, this happened:

```
Traceback (most recent call last):
  File "Backtest_Strategy.py", line 134, in <module>
    Main()
  File "Backtest_Strategy.py", line 130, in Main
    ], show_plot=True)
  File "/home/gabriel-milan/GIT_REPOS/pyjuque/pyjuque/Plotting/__init__.py", line 316, in PlotData
    plot(fig, filename=os.path.join(file_path, plot_title+'.html'), auto_open=show_plot)
  File "/home/gabriel-milan/.local/lib/python3.7/site-packages/plotly/offline/offline.py", line 597, in plot
    auto_open=auto_open,
  File "/home/gabriel-milan/.local/lib/python3.7/site-packages/plotly/io/_html.py", line 527, in write_html
    with open(file, "w") as f:
FileNotFoundError: [Errno 2] No such file or directory: '/home/gabriel-milan/GIT_REPOS/pyjuque/examples/graphs/Unnamed.html'
```

This was due to the missing directory when plotting. It's a very simple fix and that is what I wanted to bring on this PR. I'm still on my first steps with pyjuque, and it would be awesome to be able to contribute more in the future.

Best regards,
Gabriel Milan