### PR TITLE
[FIX] Not enough data for computing profit on backtesting

### DIFF
--- a/pyjuque/Engine/BacktesterSundayTheQuant.py
+++ b/pyjuque/Engine/BacktesterSundayTheQuant.py
@@ -46,6 +46,10 @@ class Backtester():
 
         self.strategy = params['strategy']['class'](**params['strategy']['params'])
 
+        self.sell_on_end = False
+        if 'sell_on_end' in params:
+            self.sell_on_end = params['sell_on_end']
+
         self.amount = 0
         self.fee_cost = 0.1 / 100
         self.balance = self.initial_balance
@@ -285,6 +289,15 @@ class Backtester():
                 if previous_stop_loss > self.stop_loss_price:
                     self.stop_loss_price = previous_stop_loss
                 
+        if (len(self.entries) > len(self.exits)) and self.sell_on_end:
+            self.close_position(price = close[i], time = time[i])
+
+        if (len(self.entries) == 0) or (len(self.exits) == 0):
+            raise ValueError("""
+            Not enough data for computing profits. Either your long or short signal wasn't triggered.
+            Please check your strategies and try again. If you have at least one entry but no exits,
+            you can force a full sell on the end by setting 'sell_on_end' to True on your bot config.
+            (Total entries: {} / Total exits: {})""".format(len(self.entries), len(self.exits)))
 
         self.first_price = close[0]
         last_price = close[len(close) - 1]

--- a/pyjuque/Engine/BacktesterSundayTheQuant.py
+++ b/pyjuque/Engine/BacktesterSundayTheQuant.py
@@ -43,12 +43,11 @@ class Backtester():
         self.exit_on_long = False
         if params['exit_settings'].__contains__('exit_on_signal'):
             self.exit_on_long = params['exit_settings']['exit_on_signal']
+        self.sell_on_end = False
+        if params['exit_settings'].__contains__('sell_on_end'):
+            self.sell_on_end = params['exit_settings']['sell_on_end']
 
         self.strategy = params['strategy']['class'](**params['strategy']['params'])
-
-        self.sell_on_end = False
-        if 'sell_on_end' in params:
-            self.sell_on_end = params['sell_on_end']
 
         self.amount = 0
         self.fee_cost = 0.1 / 100


### PR DESCRIPTION
I've noticed that, sometimes, if neither your short signal nor stop_loss triggers, there's not an exit from positions. For that particular reason, you may bump into something like this

```
Traceback (most recent call last):
  File "backtesting.py", line 53, in <module>
    Main()
  File "backtesting.py", line 29, in Main
    bt.backtest(df)
  File "/home/gabriel-milan/.local/lib/python3.7/site-packages/pyjuque/Engine/BacktesterSundayTheQuant.py", line 291, in backtest
    last_exit = self.exits[len(self.exits) - 1]
IndexError: list index out of range
```

For it to be fixed, I've implemented a flag on the bot config called `sell_on_end` (defaults to `False` for backwards compatibility) which tells the backtester to sell positions on data end. Beside that, I've also added a friendly message for this kind of error, just in case it still happens:

```
Traceback (most recent call last):
  File "backtesting.py", line 53, in <module>
    Main()
  File "backtesting.py", line 29, in Main
    bt.backtest(df)
  File "/home/gabriel-milan/.local/lib/python3.7/site-packages/pyjuque/Engine/BacktesterSundayTheQuant.py", line 300, in backtest
    (Total entries: {} / Total exits: {})""".format(len(self.entries), len(self.exits)))
ValueError: 
            Not enough data for computing profits. Either your long or short signal wasn't triggered.
            Please check your strategies and try again. If you have at least one entry but no exits,
            you can force a full sell on the end by setting 'sell_on_end' to True on your bot config.
            (Total entries: 1 / Total exits: 0)
```